### PR TITLE
Hotfix/submenu kids margin

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -2466,8 +2466,6 @@ select {
   margin-bottom: 0;
 }
 .product-nav-viewcategory{
-  margin:auto;
-  /* width: 240px; */
   height: auto;
 }
 .product-gallery {


### PR DESCRIPTION
## Hotfix: Eliminación de estilo en submenu
#### What does this PR do?
   Visualización del submenú sin un gran margen en el top al seleccionar productos en kids
#### Where should the reviewer start?
  Al seleccionar un producto y realizar la redirección, se desplega un menú, debe mantenerse el menú con un margin a la altura      de la información del producto 
#### How should this be manually tested? (optional)
    El estilo se puede verificar en la clase product-nav-viewcategory del documento main.css 
#### Any background context you want to provide? (optional)
   Revisar test de vista en producción
#### Questions (optional)
None
#### Checklist
None